### PR TITLE
Doplnený chýbajúci parameter $ref do metódy apiGetPackage.

### DIFF
--- a/NeoshipSdk.php
+++ b/NeoshipSdk.php
@@ -336,9 +336,10 @@ class NeoshipSdk
     /**
      * Returns package with given ID, returns all for current user if no ID is given
      * @param  [int]      $id   package id
+     * @param  [array]      $ref   packages
      * @return [object]
      */
-    public function apiGetPackage($id = null)
+    public function apiGetPackage($id = null, $ref = NULL)
     {
         $_SESSION['apiName'] = 'getPackage';
         $_SESSION['data1'] = $id;


### PR DESCRIPTION
V tele metódy sa používa premenná $ref, ktorá nebola inicializovaná. Podľa mňa mala byť ako parameter definovaná. Neviem však akú hodnotu by mal tento parameter držať. Pošlem pull request, ale prípadne treba doplniť do komentárov dátový typ + popis, ak som tam dal nesprávny.
